### PR TITLE
fixed: 只会读第一个不为空的`Cacheable`

### DIFF
--- a/Sources/Storage.swift
+++ b/Sources/Storage.swift
@@ -49,8 +49,11 @@ public final class Storage<T: Codable> {
     
     /// Read disk data or memory data.
     public func read(key: String, options: CachedOptions) -> Data? {
-        for named in options.cacheNameds() where self.caches[named] != nil {
-            return self.caches[named]!.read(key: key)
+        for named in options.cacheNameds() {
+            guard let value = self.caches[named]?.read(key: key) else {
+                continue
+            }
+            return value
         }
         return nil
     }


### PR DESCRIPTION
比如，重启以后，数据写到了磁盘中，
第一个不为空的`Cacheable`为`memory`，
但此时数据是在 disk 中